### PR TITLE
Update dayinfo.js

### DIFF
--- a/desktop/js/dayinfo.js
+++ b/desktop/js/dayinfo.js
@@ -37,10 +37,10 @@ function addCmdToTable(_cmd) {
         var disabled = (init(_cmd.configuration.virtualAction) == '1') ? 'disabled' : '';
         var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '">';
         tr += '<td>';
-			tr += '<span class="cmdAttr" data-l1key="id"></span>';
+	tr += '<span class="cmdAttr" data-l1key="id"></span>';
         tr += '</td>';
         tr += '<td>';
-			tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" style="width : 140px;" placeholder="{{Nom de l\'info}}"></td>';
+	tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" style="width : 140px;" placeholder="{{Nom de l\'info}}"></td>';
       tr += '<td>';
       tr += '<span class="cmdAttr" data-l1key="logicalId"></span>';
       tr += '</td>';
@@ -48,8 +48,10 @@ function addCmdToTable(_cmd) {
       tr += '<span class="cmdAttr" data-l1key="configuration" data-l2key="value"></span>';
       tr += '</td>';
         tr += '<td>';
-        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
-        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span> ';
+	tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/>{{Afficher}}</label></span> ';
+        if (is_numeric(_cmd.id)) {
+		tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
+        }
         tr += '</td>';
         tr += '<td>';
         if (is_numeric(_cmd.id)) {


### PR DESCRIPTION
- "historiser" dispo uniquement si cmd numérique
- inversion de l'ordre d'affichage des cases à cocher 'Afficher' , 'Historiser' 