### PR TITLE
initialize $debutete

### DIFF
--- a/core/class/dayinfo.class.php
+++ b/core/class/dayinfo.class.php
@@ -357,6 +357,7 @@ class dayinfo extends eqLogic {
         $diffday = 365;
         $diffend = 365;
         $finete = date_create(mktime(0, 0, 0, 1,  1));
+        $debutete = $finete;
 
         foreach ($events as $event) {
             if (isset($event['DTEND'])) {


### PR DESCRIPTION
Avec le calendrier des congés de la Belgique, ce jour tout est bien calculé par rapport au prochaine vacances mais à la ligne 407 il y a ce bloc dont je ne comprend pas exactement le but: je suppose qu'il doit servir pour gérer un cas d'exception en France sur les vacances d'été qui ne n'ont pas de date de fin définie dans le calendrier?:
```
        if ($datetoday < $debutete) {
            $diff = date_diff($datetoday, $debutete);
            if ($diff->format('%a') < $diffday && $diff->format('%a') > 0) {
                $diffday = $diff->format('%a');
                $nextlabel = "Vacances d'été";
            }
        }
```

Le problème est que `$debutete` n'est pas initialisé et ensuite il y a un comportement étrange: le premier if est validé, ensuite $diff contient et valeur farfelue qui fait que le if suivant est aussi validé et au final on se retrouve avec dayinfo qui nous dit aujourd'hui que nous sommes en période de vacances scolaire et que ce sont les "Vacances d'été":
![image](https://user-images.githubusercontent.com/41119856/103535458-066d8f80-4e91-11eb-8caf-fe97e1abf7a7.png)

au lieu de ceci avec le PR que je propose pour initialiser `$debutete` qui du coup affiche le résultat correcte:
![image](https://user-images.githubusercontent.com/41119856/103535419-f35abf80-4e90-11eb-9751-f9ee60a9ee3c.png)
